### PR TITLE
build: Add GNUmakefile for CI build & packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 # Folders
 _obj
 _test
+bin/
+pkg/
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,34 @@
+NAME ?= $(shell basename "$(CURDIR)")
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
+SOURCE_FILES = $(shell find $(CURDIR) -type f -name '*.go')
+PKG_FILES = bin/*
+
+EFFECTIVE_LD_FLAGS ?= "-X main.GitCommit=$(GIT_COMMIT) $(LD_FLAGS)"
+
+default: help
+
+bin: bin/$(NAME) ## Build application binary
+
+pkg: pkg/$(NAME).tar.gz ## Build application 'serviceball'
+
+bin/$(NAME): $(SOURCE_FILES)
+	go build -o "bin/$(NAME)" -ldflags $(EFFECTIVE_LD_FLAGS) .
+
+pkg/$(NAME).tar.gz: bin/$(NAME)
+	mkdir -p pkg/
+	tar -czf pkg/$(NAME).tar.gz --xform='s,bin/,,' --xform='s,_build/,,' $(PKG_FILES)
+
+.PHONY: clean
+clean: ## Clean build environment
+	rm -r $(CURDIR)/bin
+	rm -r $(CURDIR)/pkg
+
+.PHONY: test
+test: ## Run tests, excluding forked dependencies
+	go test -v $(shell go list ./... | grep -v vendor/)
+	#go test -v -race $(shell go list ./... | grep -v vendor/)
+
+.PHONY: help
+help:
+	@echo "Valid targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
This commit adds a makefile which follows our standard bin/pkg set of targets for CI building nomad jobs. It is not required unless building under CI - `go get` still works correctly.